### PR TITLE
feat(ApplicationsListPage): enhance country application totals fetching

### DIFF
--- a/src/components/applications/ApplicationsListPage.tsx
+++ b/src/components/applications/ApplicationsListPage.tsx
@@ -16,6 +16,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
 import { COUNTRIES, COUNTRY_IMAGE_URLS } from "@/lib/applications/utils";
 import { ROLES } from "@/lib/roles";
+import { API_ENDPOINTS } from "@/lib/config/api";
 import type {
   Country,
   ApplicationsFilters as ApplicationsFiltersType,
@@ -157,6 +158,21 @@ export const ApplicationsListPage = memo(function ApplicationsListPage({
 
   const { countryTotals, visibleCountries } = useCountryApplicationTotals({
     countries: allowedCountries,
+    getUrl: (country) => {
+      const params = new URLSearchParams();
+      params.set("page", "1");
+      params.set("limit", "1");
+      params.set("country", country);
+
+      if (type === "spouse") {
+        return API_ENDPOINTS.VISA_APPLICATIONS.SPOUSE.LIST(params.toString());
+      }
+      return API_ENDPOINTS.VISA_APPLICATIONS.LIST(params.toString());
+    },
+    queryKeyPrefix:
+      type === "spouse"
+        ? (["spouse-applications", "totals"] as const)
+        : (["applications", "totals"] as const),
   });
 
   // If the currently-selected country is hidden (0 total), fall back.

--- a/src/hooks/useCountryApplicationTotals.ts
+++ b/src/hooks/useCountryApplicationTotals.ts
@@ -6,28 +6,28 @@ import qs from "query-string";
 import type { Country } from "@/types/applications";
 import type { ApplicationsResponse } from "@/types/applications";
 import { fetcher } from "@/lib/fetcher";
-import { ZOHO_BASE_URL } from "@/lib/config/api";
 import { COUNTRIES } from "@/lib/applications/utils";
 
 type UseCountryApplicationTotalsOptions = {
   countries?: readonly Country[];
   staleTimeMs?: number;
+  /** Returns a full URL for the totals query for a given country. */
+  getUrl: (country: Country) => string;
+  queryKeyPrefix?: readonly string[];
 };
 
 export function useCountryApplicationTotals({
   countries = COUNTRIES,
   staleTimeMs = 1000 * 60 * 5,
-}: UseCountryApplicationTotalsOptions = {}) {
+  getUrl,
+  queryKeyPrefix = ["applications", "totals"],
+}: UseCountryApplicationTotalsOptions) {
   const queries = useQueries({
     queries: countries.map((country) => {
-      const query = qs.stringify(
-        { page: 1, limit: 1, country },
-        { skipNull: true, skipEmptyString: true },
-      );
-      const url = `${ZOHO_BASE_URL}/visa_applications?${query}`;
+      const url = getUrl(country);
 
       return {
-        queryKey: ["applications", "totals", country] as const,
+        queryKey: [...queryKeyPrefix, country] as const,
         queryFn: () => fetcher<ApplicationsResponse>(url),
         staleTime: staleTimeMs,
         gcTime: staleTimeMs * 2,


### PR DESCRIPTION
- Added a `getUrl` function to dynamically construct API endpoints for fetching application totals based on country and type (spouse or general).
- Updated `useCountryApplicationTotals` hook to utilize the new `getUrl` function, improving flexibility in API calls.
- Introduced a `queryKeyPrefix` parameter to allow for more descriptive query keys based on application type.