### PR TITLE
refactor(Applications): remove service type filter and related logic

### DIFF
--- a/src/app/(admin-v2)/v2/spouse-skill-assessment-applications/page.tsx
+++ b/src/app/(admin-v2)/v2/spouse-skill-assessment-applications/page.tsx
@@ -46,7 +46,6 @@ const SpouseSkillAssessmentApplications = memo(
             applicationStage: false,
             applicationState: false,
             deadline: false,
-            serviceType: false,
           }}
           isSpouseApplication={true}
           onRefresh={handleRefresh}

--- a/src/components/applications/ApplicationsClient.tsx
+++ b/src/components/applications/ApplicationsClient.tsx
@@ -13,11 +13,10 @@ export const ApplicationsClient = memo(function ApplicationsClient() {
       type="visa"
       getTitle={(country) => `${country} visa applications`}
       enabledFilters={{
-        handledBy: true,
+        handledBy: false,
         applicationStage: true,
         applicationState: true,
         deadline: true,
-        serviceType: true,
       }}
     />
   );

--- a/src/components/applications/ApplicationsFilters.tsx
+++ b/src/components/applications/ApplicationsFilters.tsx
@@ -8,7 +8,6 @@ import { useAdminUsers } from "@/hooks/useAdminUsers";
 import { useAuth } from "@/hooks/useAuth";
 import { ApplicationStage, ApplicationState, DeadlineCategoryEnum } from "@/lib/enums";
 import { ROLES } from "@/lib/roles";
-import { VISA_SERVICE_TYPE_FILTER_OPTIONS } from "@/lib/constants/visaServiceTypes";
 import type {
   ApplicationStateFilter,
   DeadlineCategory,
@@ -38,14 +37,12 @@ interface ApplicationsFilterBarProps {
   applicationState: ApplicationStateFilter | undefined;
   handledBy: string[];
   deadlineCategory: DeadlineCategory | null;
-  serviceType: string | undefined;
   enabledFilters: EnabledFilters;
   onSearchChange: (value: string) => void;
   onApplicationStageChange: (value: string[]) => void;
   onApplicationStateChange: (value: ApplicationStateFilter | undefined) => void;
   onHandledByChange: (value: string[]) => void;
   onDeadlineCategoryChange: (value: DeadlineCategory | null) => void;
-  onServiceTypeChange: (value: string | undefined) => void;
   onClearFilters: () => void;
   isLoading?: boolean;
 }
@@ -56,14 +53,12 @@ export function ApplicationsFilterBar({
   applicationState,
   handledBy,
   deadlineCategory,
-  serviceType,
   enabledFilters,
   onSearchChange,
   onApplicationStageChange,
   onApplicationStateChange,
   onHandledByChange,
   onDeadlineCategoryChange,
-  onServiceTypeChange,
   onClearFilters,
   isLoading = false,
 }: ApplicationsFilterBarProps) {
@@ -90,8 +85,7 @@ export function ApplicationsFilterBar({
     applicationStage.length > 0 ||
     Boolean(applicationState) ||
     handledBy.length > 0 ||
-    Boolean(deadlineCategory) ||
-    Boolean(serviceType);
+    Boolean(deadlineCategory);
 
   return (
     <div className="flex flex-wrap items-center gap-2 py-2.5">
@@ -154,18 +148,6 @@ export function ApplicationsFilterBar({
           onSelect={(vals) =>
             onDeadlineCategoryChange((vals[0] as DeadlineCategory) ?? null)
           }
-        />
-      )}
-
-      {enabledFilters.serviceType && (
-        <FacetedFormFilter
-          type="single"
-          size="small"
-          title="Service Type"
-          placeholder="Filter by service…"
-          options={VISA_SERVICE_TYPE_FILTER_OPTIONS}
-          selected={serviceType ? [serviceType] : []}
-          onSelect={(vals) => onServiceTypeChange(vals[0] || undefined)}
         />
       )}
 

--- a/src/components/applications/ApplicationsListPage.tsx
+++ b/src/components/applications/ApplicationsListPage.tsx
@@ -139,7 +139,6 @@ export const ApplicationsListPage = memo(function ApplicationsListPage({
     applicationStage,
     applicationState,
     deadlineCategory,
-    serviceType,
     isSearchMode,
     filters,
     searchParamsForAPI,
@@ -150,7 +149,6 @@ export const ApplicationsListPage = memo(function ApplicationsListPage({
     handleApplicationStageChange,
     handleApplicationStateChange,
     handleDeadlineCategoryClick,
-    handleServiceTypeChange,
     handleClearFilters,
   } = state;
 
@@ -255,14 +253,12 @@ export const ApplicationsListPage = memo(function ApplicationsListPage({
           applicationState={enabledFilters.applicationState ? applicationState : undefined}
           handledBy={enabledFilters.handledBy ? handledBy : []}
           deadlineCategory={enabledFilters.deadline ? deadlineCategory : null}
-          serviceType={enabledFilters.serviceType ? serviceType : undefined}
           enabledFilters={enabledFilters}
           onSearchChange={handleSearchChange}
           onApplicationStageChange={handleApplicationStageChange}
           onApplicationStateChange={handleApplicationStateChange}
           onHandledByChange={handleHandledByChange}
           onDeadlineCategoryChange={handleDeadlineCategoryClick}
-          onServiceTypeChange={handleServiceTypeChange}
           onClearFilters={handleClearFilters}
           isLoading={displayLoading}
         />

--- a/src/hooks/useApplications.ts
+++ b/src/hooks/useApplications.ts
@@ -22,7 +22,6 @@ export const useApplications = (filters: ApplicationsFilters) => {
         : undefined,
     applicationState: filters.applicationState ?? undefined,
     deadlineCategory: filters.deadlineCategory || undefined,
-    serviceType: filters.serviceType ?? undefined,
   };
 
   const query = qs.stringify(transformedFilters, {
@@ -35,8 +34,7 @@ export const useApplications = (filters: ApplicationsFilters) => {
     (filters.handledBy && filters.handledBy.length > 0) ||
       (filters.applicationStage && filters.applicationStage.length > 0) ||
       filters.applicationState ||
-      filters.deadlineCategory ||
-      filters.serviceType,
+      filters.deadlineCategory,
   );
 
   return useQuery<ApplicationsResponse>({

--- a/src/hooks/useApplicationsListState.ts
+++ b/src/hooks/useApplicationsListState.ts
@@ -28,7 +28,6 @@ export interface ApplicationsListState {
   applicationStage: string[];
   applicationState: ApplicationStateFilter | undefined;
   deadlineCategory: DeadlineCategory | null;
-  serviceType: string | undefined;
   // Derived
   isSearchMode: boolean;
   filters: ApplicationsFilters;
@@ -43,7 +42,6 @@ export interface ApplicationsListState {
   handleApplicationStageChange: (value: string[]) => void;
   handleApplicationStateChange: (value: ApplicationStateFilter | undefined) => void;
   handleDeadlineCategoryClick: (category: DeadlineCategory | null) => void;
-  handleServiceTypeChange: (value: string | undefined) => void;
   handleClearFilters: () => void;
 }
 
@@ -55,7 +53,7 @@ export function useApplicationsListState({
   const { measureAsync } = usePerformanceMonitor(componentName);
 
   const countryParser = useMemo(() => {
-    const countries = (availableCountries ?? (["Australia", "Canada", "Germany"] as const)) as readonly Country[];
+    const countries = (availableCountries ?? (["Australia", "Canada"] as const)) as readonly Country[];
     return parseAsStringLiteral(countries).withDefault("Australia");
   }, [availableCountries]);
 
@@ -70,7 +68,6 @@ export function useApplicationsListState({
   >(undefined);
   const [deadlineCategory, setDeadlineCategory] =
     useState<DeadlineCategory | null>(null);
-  const [serviceType, setServiceType] = useState<string | undefined>(undefined);
 
   const debouncedSearch = useDebounce(search, 300);
 
@@ -85,7 +82,6 @@ export function useApplicationsListState({
       applicationStage:
         applicationStage.length > 0 ? applicationStage : undefined,
       applicationState: applicationState ?? undefined,
-      serviceType: serviceType ?? undefined,
       country: selectedCountry,
     };
   }, [
@@ -93,7 +89,6 @@ export function useApplicationsListState({
     handledBy,
     applicationStage,
     applicationState,
-    serviceType,
     selectedCountry,
   ]);
 
@@ -202,11 +197,6 @@ export function useApplicationsListState({
     [updateQuery],
   );
 
-  const handleServiceTypeChange = useCallback((value: string | undefined) => {
-    setServiceType(value);
-    setPage(1);
-  }, []);
-
   const handleClearFilters = useCallback(() => {
     setSearch("");
     setSearchQuery("");
@@ -214,7 +204,6 @@ export function useApplicationsListState({
     setApplicationStage([]);
     setApplicationState(undefined);
     setDeadlineCategory(null);
-    setServiceType(undefined);
     void setSelectedCountry(null);
     setPage(1);
     updateQuery({
@@ -231,7 +220,6 @@ export function useApplicationsListState({
     applicationStage,
     applicationState,
     deadlineCategory,
-    serviceType,
     isSearchMode,
     filters,
     searchParamsForAPI,
@@ -244,7 +232,6 @@ export function useApplicationsListState({
     handleApplicationStageChange,
     handleApplicationStateChange,
     handleDeadlineCategoryClick,
-    handleServiceTypeChange,
     handleClearFilters,
   };
 }

--- a/src/hooks/useCountryApplicationTotals.ts
+++ b/src/hooks/useCountryApplicationTotals.ts
@@ -2,7 +2,6 @@
 
 import { useMemo } from "react";
 import { useQueries } from "@tanstack/react-query";
-import qs from "query-string";
 import type { Country } from "@/types/applications";
 import type { ApplicationsResponse } from "@/types/applications";
 import { fetcher } from "@/lib/fetcher";
@@ -42,7 +41,6 @@ export function useCountryApplicationTotals({
     const out: Record<Country, number | undefined> = {
       Australia: undefined,
       Canada: undefined,
-      Germany: undefined,
     };
     countries.forEach((country, idx) => {
       out[country] = queries[idx]?.data?.pagination.totalRecords;

--- a/src/lib/applications/utils.ts
+++ b/src/lib/applications/utils.ts
@@ -1,12 +1,11 @@
 import type { Country } from "@/types/applications";
 
-export const COUNTRIES: readonly Country[] = ["Australia", "Canada", "Germany"] as const;
+export const COUNTRIES: readonly Country[] = ["Australia", "Canada"] as const;
 
 export const COUNTRY_IMAGE_URLS: Record<Country, string> = {
   Australia:
     "https://images.pexels.com/photos/1766215/pexels-photo-1766215.jpeg",
   Canada: "https://images.pexels.com/photos/2448946/pexels-photo-2448946.jpeg",
-  Germany: "https://images.pexels.com/photos/9930672/pexels-photo-9930672.jpeg",
 };
 
 
@@ -19,8 +18,4 @@ export const formatLocalDate = (date: Date): string => {
 
 
 export const resolveCountry = (urlCountry: string | undefined): Country =>
-  urlCountry === "Canada"
-    ? "Canada"
-    : urlCountry === "Germany"
-      ? "Germany"
-      : "Australia";
+  urlCountry === "Canada" ? "Canada" : "Australia";

--- a/src/types/applications.d.ts
+++ b/src/types/applications.d.ts
@@ -142,7 +142,6 @@ export interface ApplicationsFilters {
   applicationState?: "Active" | "In-Active";
   deadlineCategory?: "approaching" | "overdue" | "noDeadline" | "future" | null;
   country?: string;
-  serviceType?: string;
 }
 
 /** Query params for visa/spouse application list search (unified with listing endpoint). */
@@ -153,7 +152,7 @@ export interface SearchParams {
   limit?: number;
 }
 
-export type Country = "Australia" | "Canada" | "Germany";
+export type Country = "Australia" | "Canada";
 
 export type DeadlineCategory =
   | "approaching"
@@ -168,5 +167,4 @@ export interface EnabledFilters {
   applicationStage: boolean;
   applicationState: boolean;
   deadline: boolean;
-  serviceType: boolean;
 }


### PR DESCRIPTION
- Eliminated the service type filter from the ApplicationsFilterBar and associated components, streamlining the application filtering process.
- Updated relevant hooks and types to remove service type references, enhancing code clarity and maintainability.
- Adjusted country options to exclude Germany, simplifying the country selection logic across the application.