### PR TITLE
feat(CallEvents): implement call event handling and disposition modal

### DIFF
--- a/src/app/(admin-v2)/layout.tsx
+++ b/src/app/(admin-v2)/layout.tsx
@@ -18,6 +18,7 @@ import { ContentArea } from "@/app/(admin-v2)/content-area";
 import { SidebarController } from "@/app/(admin-v2)/sidebar-controller";
 import { McubePhoneWidgetLoader } from "@/components/mcube/McubePhoneWidgetLoader";
 import PhoneCard from "@/components/mcube/PhoneCard";
+import { CallEventsSetup } from "@/components/mcube/CallEventsSetup";
 
 function AdminContentFallback() {
   return (
@@ -36,6 +37,7 @@ function AdminContentFallback() {
 export default async function Layout({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <CommandPaletteSetup>
+    <CallEventsSetup>
     <SidebarProvider defaultOpen={true}>
       <Suspense fallback={null}>
         <SidebarController />
@@ -90,6 +92,7 @@ export default async function Layout({ children }: Readonly<{ children: ReactNod
       {/* <McubePhoneWidgetLoader /> */}
 
     </SidebarProvider>
+    </CallEventsSetup>
     </CommandPaletteSetup>
   );
 }

--- a/src/components/mcube/CallDispositionModal.tsx
+++ b/src/components/mcube/CallDispositionModal.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { PhoneOff, Phone, User } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { useCallDispositionStore } from "@/store/callDispositionStore";
+import { updateCallNotes } from "@/lib/api/callLogs";
+import { callLogKeys } from "@/hooks/useCallLogs";
+import type { CallAgentStatus, CallLogDetailResponse, CallLogListResponse } from "@/types/callLog";
+
+const AGENT_STATUS_OPTIONS: { value: CallAgentStatus; label: string }[] = [
+  { value: "answered",                label: "Answered" },
+  { value: "unanswered",              label: "Unanswered" },
+  { value: "client_busy",             label: "Client Busy" },
+  { value: "client_asked_call_later", label: "Client Asked to Call Later" },
+  { value: "not_connected",           label: "Not Connected" },
+  { value: "none",                    label: "None" },
+];
+
+export function CallDispositionModal() {
+  const { isModalOpen, pendingCall, closeDispositionModal } = useCallDispositionStore();
+  const queryClient = useQueryClient();
+
+  const [callAgentStatus, setCallAgentStatus] = useState<CallAgentStatus | "">("");
+  const [callNote, setCallNote]               = useState("");
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: () =>
+      updateCallNotes(pendingCall!.call_id, {
+        call_agent_status: callAgentStatus || null,
+        call_note:         callNote.trim() || null,
+      }),
+    onSuccess: (res: CallLogDetailResponse) => {
+      const updated = res.data.callLog;
+
+      // Update detail cache if open
+      queryClient.setQueryData(callLogKeys.detail(updated.call_id), {
+        status: "success",
+        data:   { callLog: updated },
+      });
+
+      // Update all list caches in-place
+      queryClient.setQueriesData<CallLogListResponse>(
+        { queryKey: callLogKeys.all(), exact: false },
+        (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            data: {
+              callLogs: old.data.callLogs.map((log) =>
+                log.call_id === updated.call_id ? updated : log,
+              ),
+            },
+          };
+        },
+      );
+
+      handleClose();
+    },
+  });
+
+  function handleClose() {
+    setCallAgentStatus("");
+    setCallNote("");
+    closeDispositionModal();
+  }
+
+  if (!pendingCall) return null;
+
+  return (
+    <Dialog open={isModalOpen} onOpenChange={(open) => { if (!open) handleClose(); }}>
+      <DialogContent className="max-w-[460px] gap-5 p-5">
+        {/* Header */}
+        <div className="flex items-start gap-3">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-red-100 text-red-600 dark:bg-red-900/40 dark:text-red-400">
+            <PhoneOff className="size-4" />
+          </div>
+          <div>
+            <DialogTitle className="text-base font-semibold leading-snug">
+              Call Ended
+            </DialogTitle>
+            <DialogDescription className="mt-0.5 text-sm text-muted-foreground">
+              Log a disposition for this call before dismissing.
+            </DialogDescription>
+          </div>
+        </div>
+
+        {/* Call summary */}
+        <div className="rounded-lg border bg-muted/40 px-4 py-3 space-y-1.5 text-sm">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <User className="size-3.5 shrink-0" />
+            <span className="truncate">{pendingCall.client_name ?? "Unknown Caller"}</span>
+          </div>
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Phone className="size-3.5 shrink-0" />
+            <span>{pendingCall.customer_phone}</span>
+          </div>
+        </div>
+
+        {/* Form */}
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="call-agent-status">Call Outcome</Label>
+            <Select
+              value={callAgentStatus}
+              onValueChange={(v) => setCallAgentStatus(v as CallAgentStatus)}
+            >
+              <SelectTrigger id="call-agent-status">
+                <SelectValue placeholder="Select outcome…" />
+              </SelectTrigger>
+              <SelectContent>
+                {AGENT_STATUS_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="call-note">
+              Note{" "}
+              <span className="font-normal text-muted-foreground">(optional)</span>
+            </Label>
+            <Textarea
+              id="call-note"
+              rows={3}
+              placeholder="Add a note about this call…"
+              value={callNote}
+              onChange={(e) => setCallNote(e.target.value)}
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="-mx-5 -mb-5 flex items-center justify-between border-t bg-muted/50 px-5 py-3">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleClose}
+            disabled={isPending}
+          >
+            Dismiss
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => mutate()}
+            disabled={isPending}
+            className="bg-neutral-900 text-white"
+          >
+            {isPending ? "Saving…" : "Save & Close"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/mcube/CallEventsSetup.tsx
+++ b/src/components/mcube/CallEventsSetup.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCallEvents } from "@/hooks/useCallEvents";
+import { CallDispositionModal } from "@/components/mcube/CallDispositionModal";
+
+export function CallEventsSetup({ children }: { children: ReactNode }) {
+  useCallEvents();
+  return (
+    <>
+      {children}
+      <CallDispositionModal />
+    </>
+  );
+}

--- a/src/hooks/useCallEvents.ts
+++ b/src/hooks/useCallEvents.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { notificationSocket } from "@/lib/notificationSocket";
+import { callLogKeys } from "@/hooks/useCallLogs";
+import { useLayoutStore } from "@/store/layoutStore";
+import { useCallDispositionStore } from "@/store/callDispositionStore";
+import type { CallLog, CallLogListResponse } from "@/types/callLog";
+
+export function useCallEvents() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    // ── Broadcast: keep call-log list cache up to date for all staff ──────────
+    const unsubNew = notificationSocket.onCallLogNew((doc: CallLog) => {
+      queryClient.setQueriesData<CallLogListResponse>(
+        { queryKey: callLogKeys.all(), exact: false },
+        (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            results: old.results + 1,
+            pagination: {
+              ...old.pagination,
+              totalRecords: old.pagination.totalRecords + 1,
+            },
+            data: { callLogs: [doc, ...old.data.callLogs] },
+          };
+        },
+      );
+    });
+
+    const unsubUpdated = notificationSocket.onCallLogUpdated((doc: CallLog) => {
+      queryClient.setQueriesData<CallLogListResponse>(
+        { queryKey: callLogKeys.all(), exact: false },
+        (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            data: {
+              callLogs: old.data.callLogs.map((log) =>
+                log.call_id === doc.call_id ? doc : log,
+              ),
+            },
+          };
+        },
+      );
+      queryClient.setQueryData(callLogKeys.detail(doc.call_id), {
+        status: "success",
+        data:   { callLog: doc },
+      });
+    });
+
+    // ── Targeted: action triggers for the specific agent only ─────────────────
+    const unsubInbound = notificationSocket.onCallInbound(() => {
+      useLayoutStore.getState().openPhonePanel();
+    });
+
+    const unsubHangup = notificationSocket.onCallHangup((doc: CallLog) => {
+      useCallDispositionStore.getState().openDispositionModal(doc);
+    });
+
+    return () => {
+      unsubNew();
+      unsubUpdated();
+      unsubInbound();
+      unsubHangup();
+    };
+  }, [queryClient]);
+}

--- a/src/lib/api/callLogs.ts
+++ b/src/lib/api/callLogs.ts
@@ -4,6 +4,7 @@ import type {
   CallLogListFilters,
   CallLogListResponse,
   CallLogDetailResponse,
+  UpdateCallNotesPayload,
 } from "@/types/callLog";
 
 export async function getCallLogs(
@@ -26,4 +27,14 @@ export async function getCallLogs(
 
 export async function getCallLogDetail(callId: string): Promise<CallLogDetailResponse> {
   return fetcher<CallLogDetailResponse>(API_ENDPOINTS.CALL_LOGS.BY_ID(callId));
+}
+
+export async function updateCallNotes(
+  callId: string,
+  payload: UpdateCallNotesPayload,
+): Promise<CallLogDetailResponse> {
+  return fetcher<CallLogDetailResponse>(API_ENDPOINTS.CALL_LOGS.NOTES(callId), {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
 }

--- a/src/lib/config/api.ts
+++ b/src/lib/config/api.ts
@@ -234,6 +234,7 @@ export const API_ENDPOINTS = {
   CALL_LOGS: {
     LIST:  (params?: string) => `${API_BASE_URL}/api/mcube/call-logs${params ? `?${params}` : ''}`,
     BY_ID: (callId: string)  => `${API_BASE_URL}/api/mcube/call-logs/${callId}`,
+    NOTES: (callId: string)  => `${API_BASE_URL}/api/mcube/call-logs/${callId}/notes`,
   },
   USERS: {
     ALL: (params: string) => `${ZOHO_BASE_URL}/users/all?${params}`,

--- a/src/lib/config/notifications.ts
+++ b/src/lib/config/notifications.ts
@@ -29,6 +29,8 @@ export const SOCKET_EVENTS = {
 export const CALL_LOG_SOCKET_EVENTS = {
   NEW:     "call-log:new",
   UPDATED: "call-log:updated",
+  INBOUND: "call:inbound",   // targeted to agent's room — triggers phone panel open
+  HANGUP:  "call:hangup",    // targeted to agent's room — triggers disposition modal
 } as const;
 
 // Connection configuration

--- a/src/lib/notificationSocket.ts
+++ b/src/lib/notificationSocket.ts
@@ -34,6 +34,8 @@ export class NotificationSocketManager {
   private stateListeners = new Set<(state: NotificationConnectionState) => void>();
   private callLogNewListeners = new Set<Listener<CallLog>>();
   private callLogUpdatedListeners = new Set<Listener<CallLog>>();
+  private callInboundListeners = new Set<Listener<CallLog>>();
+  private callHangupListeners  = new Set<Listener<CallLog>>();
 
   private connectionState: NotificationConnectionState = {
     isConnected: false,
@@ -84,6 +86,8 @@ export class NotificationSocketManager {
     this.stateListeners.clear();
     this.callLogNewListeners.clear();
     this.callLogUpdatedListeners.clear();
+    this.callInboundListeners.clear();
+    this.callHangupListeners.clear();
   }
 
   isConnected(): boolean {
@@ -150,6 +154,24 @@ export class NotificationSocketManager {
     return () => {
       this.callLogUpdatedListeners.delete(cb);
       this.socket?.off(CALL_LOG_SOCKET_EVENTS.UPDATED, cb);
+    };
+  }
+
+  onCallInbound(cb: Listener<CallLog>): () => void {
+    this.callInboundListeners.add(cb);
+    if (this.socket?.connected) this.socket.on(CALL_LOG_SOCKET_EVENTS.INBOUND, cb);
+    return () => {
+      this.callInboundListeners.delete(cb);
+      this.socket?.off(CALL_LOG_SOCKET_EVENTS.INBOUND, cb);
+    };
+  }
+
+  onCallHangup(cb: Listener<CallLog>): () => void {
+    this.callHangupListeners.add(cb);
+    if (this.socket?.connected) this.socket.on(CALL_LOG_SOCKET_EVENTS.HANGUP, cb);
+    return () => {
+      this.callHangupListeners.delete(cb);
+      this.socket?.off(CALL_LOG_SOCKET_EVENTS.HANGUP, cb);
     };
   }
 
@@ -229,6 +251,8 @@ export class NotificationSocketManager {
     for (const cb of this.presenceSnapshotListeners) s.on(PRESENCE_SOCKET_EVENTS.SNAPSHOT, cb);
     for (const cb of this.callLogNewListeners) s.on(CALL_LOG_SOCKET_EVENTS.NEW, cb);
     for (const cb of this.callLogUpdatedListeners) s.on(CALL_LOG_SOCKET_EVENTS.UPDATED, cb);
+    for (const cb of this.callInboundListeners) s.on(CALL_LOG_SOCKET_EVENTS.INBOUND, cb);
+    for (const cb of this.callHangupListeners)  s.on(CALL_LOG_SOCKET_EVENTS.HANGUP, cb);
   }
 
   private handleError(error: string): void {

--- a/src/store/callDispositionStore.ts
+++ b/src/store/callDispositionStore.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+import type { CallLog } from "@/types/callLog";
+
+type CallDispositionStore = {
+  /** The call that just hung up and is awaiting agent disposition */
+  pendingCall: CallLog | null;
+  isModalOpen: boolean;
+  openDispositionModal: (call: CallLog) => void;
+  closeDispositionModal: () => void;
+};
+
+export const useCallDispositionStore = create<CallDispositionStore>((set) => ({
+  pendingCall:          null,
+  isModalOpen:          false,
+  openDispositionModal: (call) => set({ pendingCall: call, isModalOpen: true }),
+  closeDispositionModal: ()    => set({ isModalOpen: false, pendingCall: null }),
+}));

--- a/src/types/callLog.ts
+++ b/src/types/callLog.ts
@@ -8,16 +8,21 @@ export type CallStatus =
   | 'busy'
   | 'cancelled';
 
+export type CallAgentStatus =
+  | 'unanswered'
+  | 'client_busy'
+  | 'client_asked_call_later'
+  | 'not_connected'
+  | 'answered'
+  | 'none';
+
 export type CallDirection = 'Inbound' | 'Outbound';
 
-// ── Filters passed to useCallLogs / API ─────────────────────────────────────
 
 export interface CallLogListFilters {
-  /** Free-text search — phone numbers, agent name, client name, call ID */
   q?:         string;
   status?:    CallStatus | '';
   direction?: CallDirection | '';
-  /** Named preset — takes priority over startDate/endDate */
   dateRange?: DateRangePreset | '';
   startDate?: string;
   endDate?:   string;
@@ -66,8 +71,17 @@ export interface CallLog {
   answered_duration: string | null;
   disconnected_by:   string | null;
   recording_url:     string | null;
+  call_note:         string | null;
+  call_agent_status: CallAgentStatus | null;
   created_at:        string;
   updated_at:        string;
+}
+
+// ── Mutation payloads ────────────────────────────────────────────────────────
+
+export interface UpdateCallNotesPayload {
+  call_note?:         string | null;
+  call_agent_status?: CallAgentStatus | null;
 }
 
 // ── API response shapes ──────────────────────────────────────────────────────


### PR DESCRIPTION
- Introduced `CallEventsSetup` component to manage call events and display the `CallDispositionModal` for logging call outcomes.
- Added `useCallEvents` hook to handle real-time updates for call logs, including new calls and updates.
- Created `CallDispositionModal` for agents to log call notes and outcomes, enhancing call management functionality.
- Updated API to support call note updates and modified notification socket to handle inbound call and hangup events.
- Integrated state management for call disposition using Zustand, improving user experience during call handling.