### PR TITLE
fix(ConversationList): truncate last text in conversation row for bet…

### DIFF
--- a/src/components/chat/ConversationList.tsx
+++ b/src/components/chat/ConversationList.tsx
@@ -151,7 +151,7 @@ export function ConversationRow({
           </span>
         </div>
         <div className="flex items-center justify-between gap-2 mt-0.5">
-          <p className="text-xs text-muted-foreground truncate">{lastText}</p>
+          <p className="text-xs text-muted-foreground truncate">{lastText.slice(0, 40)} {lastText.length > 40 ? "..." : ""}</p>
           {conversation.unreadCount > 0 && (
             <Badge
               variant="default"


### PR DESCRIPTION
…ter readability

- Updated the last text display in the ConversationRow component to truncate long messages to 40 characters, appending "..." for messages exceeding this length. This change enhances the user interface by preventing overflow and improving readability.