### PR TITLE
feat(Applications): add service type filter functionality

### DIFF
--- a/src/app/(admin-v2)/v2/spouse-skill-assessment-applications/page.tsx
+++ b/src/app/(admin-v2)/v2/spouse-skill-assessment-applications/page.tsx
@@ -46,6 +46,7 @@ const SpouseSkillAssessmentApplications = memo(
             applicationStage: false,
             applicationState: false,
             deadline: false,
+            serviceType: false,
           }}
           isSpouseApplication={true}
           onRefresh={handleRefresh}

--- a/src/components/applications/ApplicationsClient.tsx
+++ b/src/components/applications/ApplicationsClient.tsx
@@ -13,10 +13,11 @@ export const ApplicationsClient = memo(function ApplicationsClient() {
       type="visa"
       getTitle={(country) => `${country} visa applications`}
       enabledFilters={{
-        handledBy: false,
+        handledBy: true,
         applicationStage: true,
         applicationState: true,
         deadline: true,
+        serviceType: true,
       }}
     />
   );

--- a/src/components/applications/ApplicationsFilters.tsx
+++ b/src/components/applications/ApplicationsFilters.tsx
@@ -8,6 +8,7 @@ import { useAdminUsers } from "@/hooks/useAdminUsers";
 import { useAuth } from "@/hooks/useAuth";
 import { ApplicationStage, ApplicationState, DeadlineCategoryEnum } from "@/lib/enums";
 import { ROLES } from "@/lib/roles";
+import { VISA_SERVICE_TYPE_FILTER_OPTIONS } from "@/lib/constants/visaServiceTypes";
 import type {
   ApplicationStateFilter,
   DeadlineCategory,
@@ -37,12 +38,14 @@ interface ApplicationsFilterBarProps {
   applicationState: ApplicationStateFilter | undefined;
   handledBy: string[];
   deadlineCategory: DeadlineCategory | null;
+  serviceType: string | undefined;
   enabledFilters: EnabledFilters;
   onSearchChange: (value: string) => void;
   onApplicationStageChange: (value: string[]) => void;
   onApplicationStateChange: (value: ApplicationStateFilter | undefined) => void;
   onHandledByChange: (value: string[]) => void;
   onDeadlineCategoryChange: (value: DeadlineCategory | null) => void;
+  onServiceTypeChange: (value: string | undefined) => void;
   onClearFilters: () => void;
   isLoading?: boolean;
 }
@@ -53,12 +56,14 @@ export function ApplicationsFilterBar({
   applicationState,
   handledBy,
   deadlineCategory,
+  serviceType,
   enabledFilters,
   onSearchChange,
   onApplicationStageChange,
   onApplicationStateChange,
   onHandledByChange,
   onDeadlineCategoryChange,
+  onServiceTypeChange,
   onClearFilters,
   isLoading = false,
 }: ApplicationsFilterBarProps) {
@@ -85,7 +90,8 @@ export function ApplicationsFilterBar({
     applicationStage.length > 0 ||
     Boolean(applicationState) ||
     handledBy.length > 0 ||
-    Boolean(deadlineCategory);
+    Boolean(deadlineCategory) ||
+    Boolean(serviceType);
 
   return (
     <div className="flex flex-wrap items-center gap-2 py-2.5">
@@ -148,6 +154,18 @@ export function ApplicationsFilterBar({
           onSelect={(vals) =>
             onDeadlineCategoryChange((vals[0] as DeadlineCategory) ?? null)
           }
+        />
+      )}
+
+      {enabledFilters.serviceType && (
+        <FacetedFormFilter
+          type="single"
+          size="small"
+          title="Service Type"
+          placeholder="Filter by service…"
+          options={VISA_SERVICE_TYPE_FILTER_OPTIONS}
+          selected={serviceType ? [serviceType] : []}
+          onSelect={(vals) => onServiceTypeChange(vals[0] || undefined)}
         />
       )}
 

--- a/src/components/applications/ApplicationsListPage.tsx
+++ b/src/components/applications/ApplicationsListPage.tsx
@@ -139,6 +139,7 @@ export const ApplicationsListPage = memo(function ApplicationsListPage({
     applicationStage,
     applicationState,
     deadlineCategory,
+    serviceType,
     isSearchMode,
     filters,
     searchParamsForAPI,
@@ -149,6 +150,7 @@ export const ApplicationsListPage = memo(function ApplicationsListPage({
     handleApplicationStageChange,
     handleApplicationStateChange,
     handleDeadlineCategoryClick,
+    handleServiceTypeChange,
     handleClearFilters,
   } = state;
 
@@ -253,12 +255,14 @@ export const ApplicationsListPage = memo(function ApplicationsListPage({
           applicationState={enabledFilters.applicationState ? applicationState : undefined}
           handledBy={enabledFilters.handledBy ? handledBy : []}
           deadlineCategory={enabledFilters.deadline ? deadlineCategory : null}
+          serviceType={enabledFilters.serviceType ? serviceType : undefined}
           enabledFilters={enabledFilters}
           onSearchChange={handleSearchChange}
           onApplicationStageChange={handleApplicationStageChange}
           onApplicationStateChange={handleApplicationStateChange}
           onHandledByChange={handleHandledByChange}
           onDeadlineCategoryChange={handleDeadlineCategoryClick}
+          onServiceTypeChange={handleServiceTypeChange}
           onClearFilters={handleClearFilters}
           isLoading={displayLoading}
         />

--- a/src/components/applications/ViewDocumentSheet.tsx
+++ b/src/components/applications/ViewDocumentSheet.tsx
@@ -7,7 +7,6 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { Button } from "../ui/button";
-import { InlineToast } from "@/components/ui/primitives/inline-toast";
 import DocumentComments from "./DocumentComments";
 import CommentErrorBoundary from "./CommentErrorBoundary";
 import DocumentPreview from "./DocumentPreview";

--- a/src/components/applications/documents/DocumentTableRow.tsx
+++ b/src/components/applications/documents/DocumentTableRow.tsx
@@ -2,12 +2,9 @@
 
 import { memo } from "react";
 import {
-  RiClockwiseLine,
-  RiCloseCircleLine,
   RiDeleteBin2Line,
   RiErrorWarningFill,
   RiEyeLine,
-  RiFolderForbidFill,
   RiMore2Fill,
   RiUploadLine,
 } from "react-icons/ri";

--- a/src/hooks/useApplications.ts
+++ b/src/hooks/useApplications.ts
@@ -22,6 +22,7 @@ export const useApplications = (filters: ApplicationsFilters) => {
         : undefined,
     applicationState: filters.applicationState ?? undefined,
     deadlineCategory: filters.deadlineCategory || undefined,
+    serviceType: filters.serviceType ?? undefined,
   };
 
   const query = qs.stringify(transformedFilters, {
@@ -34,7 +35,8 @@ export const useApplications = (filters: ApplicationsFilters) => {
     (filters.handledBy && filters.handledBy.length > 0) ||
       (filters.applicationStage && filters.applicationStage.length > 0) ||
       filters.applicationState ||
-      filters.deadlineCategory,
+      filters.deadlineCategory ||
+      filters.serviceType,
   );
 
   return useQuery<ApplicationsResponse>({

--- a/src/hooks/useApplicationsListState.ts
+++ b/src/hooks/useApplicationsListState.ts
@@ -28,6 +28,7 @@ export interface ApplicationsListState {
   applicationStage: string[];
   applicationState: ApplicationStateFilter | undefined;
   deadlineCategory: DeadlineCategory | null;
+  serviceType: string | undefined;
   // Derived
   isSearchMode: boolean;
   filters: ApplicationsFilters;
@@ -42,6 +43,7 @@ export interface ApplicationsListState {
   handleApplicationStageChange: (value: string[]) => void;
   handleApplicationStateChange: (value: ApplicationStateFilter | undefined) => void;
   handleDeadlineCategoryClick: (category: DeadlineCategory | null) => void;
+  handleServiceTypeChange: (value: string | undefined) => void;
   handleClearFilters: () => void;
 }
 
@@ -68,6 +70,7 @@ export function useApplicationsListState({
   >(undefined);
   const [deadlineCategory, setDeadlineCategory] =
     useState<DeadlineCategory | null>(null);
+  const [serviceType, setServiceType] = useState<string | undefined>(undefined);
 
   const debouncedSearch = useDebounce(search, 300);
 
@@ -82,6 +85,7 @@ export function useApplicationsListState({
       applicationStage:
         applicationStage.length > 0 ? applicationStage : undefined,
       applicationState: applicationState ?? undefined,
+      serviceType: serviceType ?? undefined,
       country: selectedCountry,
     };
   }, [
@@ -89,6 +93,7 @@ export function useApplicationsListState({
     handledBy,
     applicationStage,
     applicationState,
+    serviceType,
     selectedCountry,
   ]);
 
@@ -197,6 +202,11 @@ export function useApplicationsListState({
     [updateQuery],
   );
 
+  const handleServiceTypeChange = useCallback((value: string | undefined) => {
+    setServiceType(value);
+    setPage(1);
+  }, []);
+
   const handleClearFilters = useCallback(() => {
     setSearch("");
     setSearchQuery("");
@@ -204,6 +214,7 @@ export function useApplicationsListState({
     setApplicationStage([]);
     setApplicationState(undefined);
     setDeadlineCategory(null);
+    setServiceType(undefined);
     void setSelectedCountry(null);
     setPage(1);
     updateQuery({
@@ -220,6 +231,7 @@ export function useApplicationsListState({
     applicationStage,
     applicationState,
     deadlineCategory,
+    serviceType,
     isSearchMode,
     filters,
     searchParamsForAPI,
@@ -232,6 +244,7 @@ export function useApplicationsListState({
     handleApplicationStageChange,
     handleApplicationStateChange,
     handleDeadlineCategoryClick,
+    handleServiceTypeChange,
     handleClearFilters,
   };
 }

--- a/src/types/applications.d.ts
+++ b/src/types/applications.d.ts
@@ -142,6 +142,7 @@ export interface ApplicationsFilters {
   applicationState?: "Active" | "In-Active";
   deadlineCategory?: "approaching" | "overdue" | "noDeadline" | "future" | null;
   country?: string;
+  serviceType?: string;
 }
 
 /** Query params for visa/spouse application list search (unified with listing endpoint). */
@@ -167,4 +168,5 @@ export interface EnabledFilters {
   applicationStage: boolean;
   applicationState: boolean;
   deadline: boolean;
+  serviceType: boolean;
 }


### PR DESCRIPTION
- Introduced a service type filter in the ApplicationsFilterBar, allowing users to filter applications based on service type.
- Updated relevant components and hooks to support the new filter, ensuring consistent state management and query handling.
- Enhanced the ApplicationsListPage and useApplications hooks to accommodate service type in filtering logic.
- Adjusted types to include service type in applications filters, improving overall filtering capabilities.