### PR TITLE
feat(Onboarding): add isSpouseApplication prop to onboarding components

### DIFF
--- a/src/components/applications/UnifiedApplicationDetailsPage.tsx
+++ b/src/components/applications/UnifiedApplicationDetailsPage.tsx
@@ -663,6 +663,7 @@ export default function UnifiedApplicationDetailsPage({
         applicationId={applicationId}
         application={application}
         onboarding={onboardingData}
+        isSpouseApplication={isSpouseApplication}
         open={isClientOnboardingOpen}
         onOpenChange={handleOnboardingModalOpenChange}
       />

--- a/src/components/applications/onboarding/ClientOnboardingModal.tsx
+++ b/src/components/applications/onboarding/ClientOnboardingModal.tsx
@@ -9,6 +9,7 @@ interface ClientOnboardingModalProps {
   applicationId: string;
   application: Application | null | undefined;
   onboarding: ApplicationOnboarding;
+  isSpouseApplication?: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -17,6 +18,7 @@ export function ClientOnboardingModal({
   applicationId,
   application,
   onboarding,
+  isSpouseApplication = false,
   open,
   onOpenChange,
 }: ClientOnboardingModalProps) {
@@ -30,6 +32,7 @@ export function ClientOnboardingModal({
           applicationId={applicationId}
           application={application}
           onboarding={onboarding}
+          isSpouseApplication={isSpouseApplication}
         />
       </DialogContent>
     </Dialog>

--- a/src/components/applications/onboarding/progress-section.tsx
+++ b/src/components/applications/onboarding/progress-section.tsx
@@ -24,6 +24,7 @@ interface ProgressSectionProps {
   applicationId: string;
   application: Application | null | undefined;
   onboarding: ApplicationOnboarding;
+  isSpouseApplication?: boolean;
 }
 
 interface StepActionProps {
@@ -193,7 +194,12 @@ function WelcomeHeader() {
   );
 }
 
-export function ProgressSection({ applicationId, application, onboarding }: ProgressSectionProps) {
+export function ProgressSection({
+  applicationId,
+  application,
+  onboarding,
+  isSpouseApplication = false,
+}: ProgressSectionProps) {
   const queryClient = useQueryClient();
   const { steps } = useOnboardingSteps(onboarding);
   const createAccount = useCreateClientAccount();
@@ -203,21 +209,34 @@ export function ProgressSection({ applicationId, application, onboarding }: Prog
   const accountComplete = steps[0]?.status === "completed";
 
   const updateOnboardingCache = (patch: Partial<ApplicationOnboarding>) => {
+    const applyPatch = (old: ApplicationDetailsResponse | undefined) => {
+      if (!old?.data.application_onboarding) return old;
+      return {
+        ...old,
+        data: {
+          ...old.data,
+          application_onboarding: {
+            ...old.data.application_onboarding,
+            ...patch,
+          },
+        },
+      };
+    };
+
+    if (isSpouseApplication) {
+      queryClient.setQueryData<ApplicationDetailsResponse>(
+        ["spouse-application-details", applicationId, undefined],
+        applyPatch,
+      );
+      queryClient.invalidateQueries({
+        queryKey: ["spouse-application-details", applicationId],
+      });
+      return;
+    }
+
     queryClient.setQueryData<ApplicationDetailsResponse>(
       ["application", applicationId],
-      (old) => {
-        if (!old?.data.application_onboarding) return old;
-        return {
-          ...old,
-          data: {
-            ...old.data,
-            application_onboarding: {
-              ...old.data.application_onboarding,
-              ...patch,
-            },
-          },
-        };
-      },
+      applyPatch,
     );
     queryClient.invalidateQueries({ queryKey: ["application", applicationId] });
   };


### PR DESCRIPTION
- Introduced isSpouseApplication prop to ClientOnboardingModal and ProgressSection components for better handling of spouse applications.
- Updated the ProgressSection to conditionally manage query data based on the isSpouseApplication flag, enhancing the onboarding experience for spouse applications.
- Ensured consistent state management across components by integrating the new prop where necessary.