### PR TITLE
fix(getDocumentUrl): reorder return statement for document URL retrieval

### DIFF
--- a/src/lib/documents/getDocumentUrl.ts
+++ b/src/lib/documents/getDocumentUrl.ts
@@ -14,5 +14,5 @@ export function getDocumentUrl(doc: DocUrlFields): string {
     ).replace(/\/$/, "");
     return `${base}/${doc.r2_key}`;
   }
-  return doc.download_url || doc.document_link || "";
+  return doc.document_link || doc.download_url || "";
 }


### PR DESCRIPTION
- Adjusted the return statement in getDocumentUrl function to prioritize document_link over download_url, ensuring the correct URL is returned based on available fields.