### PR TITLE
fix(useCallEvents): restrict notification display for inbound calls only

### DIFF
--- a/src/hooks/useCallEvents.ts
+++ b/src/hooks/useCallEvents.ts
@@ -56,8 +56,10 @@ export function useCallEvents() {
     // ── Targeted: action triggers for the specific agent only ─────────────────
     const unsubInbound = notificationSocket.onCallInbound((doc: CallLog) => {
       useLayoutStore.getState().openPhonePanel();
-      const caller = doc.client_name ?? doc.customer_phone ?? "Unknown";
-      showNotificationToast("Incoming call", `From: ${caller}`, undefined, { duration: 30_000 });
+      if (doc.direction === "inbound") {
+        const caller = doc.client_name ?? doc.customer_phone ?? "Unknown";
+        showNotificationToast("Incoming call", `From: ${caller}`, undefined, { duration: 30_000 });
+      }
     });
 
     const unsubHangup = notificationSocket.onCallHangup((doc: CallLog) => {


### PR DESCRIPTION
- Updated the notification logic in useCallEvents to ensure that the toast notification for incoming calls is only shown when the call direction is inbound, improving clarity and reducing unnecessary notifications.