### PR TITLE
feat(ViewDocumentSheet): add full view button for R2 documents

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,9 @@
     "allow": [
       "Bash(grep -r \"notification.*comment\\\\|comment.*notification\" src/lib src/hooks --include=*.ts --include=*.tsx)",
       "Skill(clerk-nextjs-patterns)",
-      "Skill(clerk-nextjs-patterns:*)"
+      "Skill(clerk-nextjs-patterns:*)",
+      "Bash(grep -E \"\\\\.\\(ts|tsx\\)$\")",
+      "Bash(grep -E \"\\\\.\\(tsx|jsx\\)$\")"
     ]
   },
   "hooks": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -57,7 +57,7 @@ export default function RootLayout({
             <NotificationProvider>
               <TooltipProvider>{children}</TooltipProvider>
             </NotificationProvider>
-            <Toaster />
+            <Toaster position="top-center" />
           </Providers>
           <ClarityAnalytics />
         </SmoothScroll>

--- a/src/components/applications/ViewDocumentSheet.tsx
+++ b/src/components/applications/ViewDocumentSheet.tsx
@@ -164,6 +164,7 @@ const ViewDocumentSheet: React.FC<ViewDocumentSheetProps> = ({
   const docUrl = getDocumentUrl(displayDoc);
   const viewUrl = docUrl;
   const downloadUrl = docUrl || undefined;
+  const isR2Document = displayDoc.storage_type === "r2";
 
   return (
     <>
@@ -335,6 +336,25 @@ const ViewDocumentSheet: React.FC<ViewDocumentSheetProps> = ({
                     isClientView={isClientView}
                   />
                   <div className="flex shrink-0 items-center gap-2">
+                    {isR2Document && viewUrl ? (
+                      <Button
+                        size="xs"
+                        variant="secondary"
+                        mode="lighter"
+                        leadingIcon={RiBookOpenLine}
+                        className="shrink-0 cursor-pointer gap-2 text-sm"
+                        onClick={() => {
+                          const opened = window.open(
+                            viewUrl,
+                            "_blank",
+                            "noopener,noreferrer",
+                          );
+                          if (opened) opened.opener = null;
+                        }}
+                      >
+                        Full view
+                      </Button>
+                    ) : null}
                     {!isClientView && (
                       <DocumentStatusButtons
                         document={displayDoc}

--- a/src/components/ui/primitives/sonner-helpers.tsx
+++ b/src/components/ui/primitives/sonner-helpers.tsx
@@ -65,7 +65,7 @@ export const showWarningToast = (message: string | ReactNode, title?: string, op
       </>
     ),
     options: {
-      position: 'bottom-center',
+      ...CONSISTENT_TOAST_OPTIONS,
       ...options,
     },
   });

--- a/src/hooks/useApplicationDocuments.ts
+++ b/src/hooks/useApplicationDocuments.ts
@@ -11,7 +11,7 @@ export function useApplicationDocuments(id: string) {
     enabled: !!id,
     staleTime: 5 * 60 * 1000,
     gcTime: 15 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
     refetchOnMount: false,
     retry: 2,
   });
@@ -33,7 +33,7 @@ export function useAllApplicationDocuments(
     enabled: enabled && !!id,
     staleTime: 5 * 60 * 1000,
     gcTime: 15 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
     refetchOnMount: false,
     retry: 2,
   });

--- a/src/hooks/useClientDocuments.ts
+++ b/src/hooks/useClientDocuments.ts
@@ -33,7 +33,7 @@ export function useClientDocuments(page: number = 1, limit: number = 10) {
     staleTime: 2 * 60 * 1000,
     retry: 1,
     retryOnMount: false,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
   });
 }
 
@@ -68,6 +68,6 @@ export function useAllClientDocuments() {
     staleTime: 2 * 60 * 1000,
     retry: 1,
     retryOnMount: false,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
   });
 }

--- a/src/hooks/useReuploadDocument.ts
+++ b/src/hooks/useReuploadDocument.ts
@@ -14,7 +14,7 @@ export function useReuploadDocument() {
 
   return useMutation<ReuploadDocumentResponse, Error, ReuploadDocumentRequest>({
     mutationFn: reuploadDocument,
-    onSuccess: (data, variables) => {
+    onSuccess: (_data, variables) => {
       // First, optimistically update the document status in the cache
       queryClient.setQueryData<{ success: boolean; data: Document[] }>(
         ["application-documents", variables.applicationId],
@@ -72,48 +72,6 @@ export function useReuploadDocument() {
                     reject_message: undefined,
                     file_name: variables.file.name,
                     uploaded_at: new Date().toISOString(),
-                    history: [
-                      ...doc.history,
-                      {
-                        _id: `temp-reupload-${Date.now()}`,
-                        status: "pending",
-                        changed_by: variables.uploaded_by,
-                        changed_at: new Date().toISOString(),
-                      },
-                    ],
-                  }
-                : doc,
-            ),
-          },
-        };
-      });
-
-      // Update client documents cache (all documents)
-      queryClient.setQueryData<{
-        success: boolean;
-        data: { documents: ClientDocument[] };
-      }>(["client-documents-all"], (old) => {
-        if (
-          !old ||
-          !old.data ||
-          !old.data.documents ||
-          !Array.isArray(old.data.documents)
-        ) {
-          return old;
-        }
-
-        return {
-          ...old,
-          data: {
-            ...old.data,
-            documents: old.data.documents.map((doc) =>
-              doc._id === variables.documentId
-                ? {
-                    ...doc,
-                    status: "pending", // Reset to pending after reupload
-                    reject_message: undefined, // Clear rejection message
-                    file_name: variables.file.name, // Update filename
-                    uploaded_at: new Date().toISOString(), // Update upload time
                     history: [
                       ...doc.history,
                       {


### PR DESCRIPTION
- Introduced a new button in the ViewDocumentSheet component that allows users to open R2 documents in a full view.
- Updated layout settings for the Toaster component to position it at the top center.
- Enhanced settings to include additional Bash commands for improved file type filtering.
- Modified toast notification options for consistent positioning across the application.
- Enabled refetching on window focus for various document hooks to ensure up-to-date data retrieval.