### PR TITLE
refactor(useDocumentStatusUpdate): streamline document link retrieval…

### DIFF
--- a/src/hooks/useDocumentStatusUpdate.ts
+++ b/src/hooks/useDocumentStatusUpdate.ts
@@ -395,22 +395,17 @@ export function useDocumentStatusUpdate({
         data.documentId
       ) {
         try {
-          // Prefer the snapshot URL the backend just returned — it reflects the
-          // post-move path after the file was archived to the deleted folder.
-          const snapshotUrl = data.response?.rejection_snapshot_url;
-          let documentLink: string | undefined = snapshotUrl ?? undefined;
+          // Prefer the per-document cache, since it is always present here and should
+          // already include the versioned `r2_key` after reupload.
+          const cachedDoc = queryClient.getQueryData<Document>([
+            "document",
+            data.documentId,
+          ]);
+          let documentLink = cachedDoc
+            ? getDocumentUrl(cachedDoc).trim() || undefined
+            : undefined;
 
-          // Fall back to cached/refetched URL for WorkDrive docs where snapshot is null.
-          if (!documentLink) {
-            const cachedDoc = queryClient.getQueryData<Document>([
-              "document",
-              data.documentId,
-            ]);
-            documentLink = cachedDoc
-              ? getDocumentUrl(cachedDoc).trim() || undefined
-              : undefined;
-          }
-
+          // Fallback: refetch the list and derive the link from the fresh list item.
           if (!documentLink) {
             await queryClient.refetchQueries({
               queryKey: ["application-documents", applicationId],

--- a/src/lib/api/updateDocumentStatus.ts
+++ b/src/lib/api/updateDocumentStatus.ts
@@ -15,8 +15,6 @@ export interface UpdateDocumentStatusResponse {
     status: string;
     changed_by: string;
     changed_at: string;
-    document_link?: string | null;
-    rejection_snapshot_url?: string | null;
   };
 }
 


### PR DESCRIPTION
… process

- Updated the logic to prioritize cached document data for link retrieval, ensuring it reflects the latest version after reupload.
- Removed the optional fields for document link and rejection snapshot URL from the UpdateDocumentStatusResponse interface, simplifying the response structure.
- Enhanced fallback mechanism to refetch document list if cached data is unavailable, improving robustness in document link handling.