### PR TITLE
refactor(upload-documents): update document structure for consistency…

### DIFF
--- a/src/components/applications/UploadDocumentsModal.tsx
+++ b/src/components/applications/UploadDocumentsModal.tsx
@@ -474,19 +474,12 @@ export function UploadDocumentsModal(props: DocumentUploadModalProps) {
           const apiCategory = getDocumentCategory(effectiveCategory);
           const displayCategory = getDisplayCategory(apiCategory);
 
-          const newDocuments = uploadResult.data.map(
-            (doc: {
-              id: string;
-              name: string;
-              size: number;
-              type: string;
-              uploaded_at: string;
-            }) => ({
-              _id: doc.id,
+          const newDocuments = uploadResult.data.map((doc) => ({
+              _id: doc._id,
               record_id: applicationId,
-              workdrive_file_id: doc.id,
+              workdrive_file_id: doc._id,
               workdrive_parent_id: "",
-              file_name: doc.name,
+              file_name: doc.file_name,
               uploaded_by: uploadedBy,
               status: "pending" as const,
               history: [],

--- a/src/lib/api/addDocument.ts
+++ b/src/lib/api/addDocument.ts
@@ -17,11 +17,13 @@ export interface AddDocumentRequest {
 export interface AddDocumentResponse {
   success: boolean;
   data: {
-    id: string;
-    name: string;
-    size: number;
-    type: string;
+    _id: string;
+    file_name: string;
+    document_name: string;
+    document_category: string;
+    document_type?: string;
     uploaded_at: string;
+    status: string;
   }[];
   message?: string;
 }

--- a/src/lib/api/clientDocumentUpload.ts
+++ b/src/lib/api/clientDocumentUpload.ts
@@ -18,11 +18,13 @@ export interface ClientUploadDocumentRequest {
 export interface ClientUploadDocumentResponse {
   success: boolean;
   data: {
-    id: string;
-    name: string;
-    size: number;
-    type: string;
+    _id: string;
+    file_name: string;
+    document_name: string;
+    document_category: string;
+    document_type?: string;
     uploaded_at: string;
+    status: string;
   }[];
   message?: string;
 }


### PR DESCRIPTION
… in API responses

- Changed document properties in UploadDocumentsModal to align with updated API response structure, including renaming 'id' to '_id' and 'name' to 'file_name'.
- Updated AddDocumentResponse and ClientUploadDocumentResponse interfaces to reflect new property names and added 'status' field for better document tracking.