### PR TITLE
feat(interest-documents): enhance support for EOI and ROI document types

### DIFF
--- a/src/components/applications/ApplicationDetailsSkeleton.tsx
+++ b/src/components/applications/ApplicationDetailsSkeleton.tsx
@@ -14,7 +14,7 @@ interface ApplicationDetailsSkeletonProps {
 const LAYOUT_TAB_LABELS = [
   "Skill Assessment",
   "Outcome",
-  "EOI",
+  "EOI/ROI",
   "Invitation",
 ] as const;
 const CATEGORY_CARD_SKELETON_COUNT = 5;

--- a/src/components/applications/ClientApplicationDetailsPageContent.tsx
+++ b/src/components/applications/ClientApplicationDetailsPageContent.tsx
@@ -157,9 +157,11 @@ export default function ClientApplicationDetailsPageContent({
   const invitationDocuments = invitationDocumentsQuery.data?.data ?? [];
   const hasInvitationDocuments = invitationDocuments.length > 0;
 
-  const eoiDocumentsQuery = useStage2Documents(applicationId, "eoi");
-  const eoiDocuments = eoiDocumentsQuery.data?.data ?? [];
-  const hasEOIDocuments = eoiDocuments.length > 0;
+  const stage2DocumentsQuery = useStage2Documents(applicationId);
+  const interestDocuments = (stage2DocumentsQuery.data?.data ?? []).filter(
+    (doc) => doc.type === "eoi" || doc.type === "roi",
+  );
+  const hasInterestDocuments = interestDocuments.length > 0;
 
   const outcomeDocumentsQuery = useStage2Documents(applicationId, "outcome");
   const outcomeDocuments = outcomeDocumentsQuery.data?.data ?? [];
@@ -172,7 +174,7 @@ export default function ClientApplicationDetailsPageContent({
       layouts.push("outcome");
     }
 
-    if (hasEOIDocuments) {
+    if (hasInterestDocuments) {
       layouts.push("eoi");
     }
 
@@ -181,7 +183,7 @@ export default function ClientApplicationDetailsPageContent({
     }
 
     return layouts;
-  }, [hasEOIDocuments, hasInvitationDocuments, hasOutcomeDocuments]);
+  }, [hasInterestDocuments, hasInvitationDocuments, hasOutcomeDocuments]);
 
   useEffect(() => {
     if (!availableLayouts.includes(selectedLayout)) {
@@ -635,7 +637,7 @@ export default function ClientApplicationDetailsPageContent({
                 </Suspense>
               ) : null
             ) : selectedLayout === "eoi" ? (
-              hasEOIDocuments ? (
+              hasInterestDocuments ? (
                 <Suspense
                   fallback={<Skeleton className="h-96 w-full rounded-xl" />}
                 >

--- a/src/components/applications/Stage2DocumentsTable.tsx
+++ b/src/components/applications/Stage2DocumentsTable.tsx
@@ -24,7 +24,8 @@ type Stage2DocumentsTableProps = {
 };
 
 function Stage2LoadingRow({ type }: { type: Stage2DocumentType }) {
-  const colCount = type === "outcome" ? 7 : type === "eoi" ? 7 : 7;
+  const colCount =
+    type === "outcome" ? 7 : type === "eoi" || type === "roi" ? 6 : 7;
   return (
     <TableRow>
       <TableCell colSpan={colCount} className="py-3">
@@ -57,14 +58,14 @@ export function Stage2DocumentsTable({
           </>
         );
       case "eoi":
+      case "roi":
         return (
           <>
             <TableHead className="min-w-0">Document Name</TableHead>
+            <TableHead className="whitespace-nowrap">Type</TableHead>
             <TableHead className="min-w-0">State</TableHead>
             <TableHead className="min-w-0">Subclass</TableHead>
-            <TableHead className="whitespace-nowrap">Points</TableHead>
             <TableHead className="whitespace-nowrap">Date</TableHead>
-            <TableHead className="whitespace-nowrap">Expiry</TableHead>
             <TableHead className="w-20 text-right">Actions</TableHead>
           </>
         );
@@ -84,7 +85,7 @@ export function Stage2DocumentsTable({
   };
 
   const displayDocuments = React.useMemo(() => {
-    if (type !== "eoi") return documents;
+    if (type !== "eoi" && type !== "roi") return documents;
     return [...documents].sort((a, b) => {
       const fileCompare = (a.document_name || a.file_name || "").localeCompare(
         b.document_name || b.file_name || "",
@@ -113,7 +114,7 @@ export function Stage2DocumentsTable({
           {displayDocuments.map((document, index) => {
             const prevDoc = index > 0 ? displayDocuments[index - 1] : null;
             const sameFileAsPrev =
-              type === "eoi" &&
+              (type === "eoi" || type === "roi") &&
               !!prevDoc &&
               (prevDoc.file_name || prevDoc.document_name) ===
                 (document.file_name || document.document_name);

--- a/src/components/applications/layouts/EOILayout.tsx
+++ b/src/components/applications/layouts/EOILayout.tsx
@@ -13,6 +13,7 @@ import {
 import { EOISheet } from "@/components/applications/stage2/sheets/EOISheet";
 import { ViewStage2DocumentModal } from "@/components/applications/stage2/ViewStage2DocumentModal";
 import type { EOILayoutProps, Stage2Document } from "@/types/stage2Documents";
+import { isInterestDocumentType } from "@/lib/stage2/interestDocument";
 import { ErrorState } from "@/components/ui/ErrorState";
 import { ConfirmationModal } from "@/components/ui/confirmation-modal";
 
@@ -34,10 +35,12 @@ export function EOILayout({
     null,
   );
 
-  const { data, isLoading, error } = useStage2Documents(applicationId, "eoi");
+  const { data, isLoading, error } = useStage2Documents(applicationId);
   const deleteMutation = useDeleteStage2Document();
 
-  const documents = data?.data || [];
+  const documents = (data?.data ?? []).filter((doc) =>
+    isInterestDocumentType(doc.type),
+  );
 
   const handleView = (document: Stage2Document) => {
     if (!getDocumentUrl(document)) {
@@ -88,22 +91,22 @@ export function EOILayout({
 
       <div className="space-y-4">
         {error ? (
-          <ErrorState title="Failed to load EOI documents" message="Please try again later." />
+          <ErrorState title="Failed to load EOI/ROI documents" message="Please try again later." />
         ) : !isLoading && documents.length === 0 ? (
           <StageDocumentsEmptyState
-            title="No EOI Yet"
-            description="No EOI documents have been uploaded for this application."
+            title="No EOI/ROI Yet"
+            description="No EOI/ROI documents have been uploaded for this application."
             isClientView={isClientView}
-            createButtonLabel="Create EOI"
+            createButtonLabel="Create EOI/ROI"
             onCreate={() => setIsModalOpen(true)}
           />
         ) : (
           <div className="pb-10">
             <div className="flex justify-between items-center mb-4">
-              <h2 className="text-lg font-medium">EOI Documents</h2>
+              <h2 className="text-lg font-medium">EOI/ROI Documents</h2>
               <StageDocumentsHeaderAction
                 isClientView={isClientView}
-                label="Add EOI"
+                label="Add EOI/ROI"
                 onClick={() => setIsModalOpen(true)}
               />
             </div>

--- a/src/components/applications/layouts/LayoutChips.tsx
+++ b/src/components/applications/layouts/LayoutChips.tsx
@@ -17,7 +17,7 @@ interface LayoutChipsProps {
 const layoutChips: { id: ApplicationLayout; label: string }[] = [
   { id: "skill-assessment", label: "Skill Assessment" },
   { id: "outcome", label: "Outcome" },
-  { id: "eoi", label: "EOI" },
+  { id: "eoi", label: "EOI/ROI" },
   { id: "invitation", label: "Invitation" },
 ];
 

--- a/src/components/applications/stage2/EOIDocumentRow.tsx
+++ b/src/components/applications/stage2/EOIDocumentRow.tsx
@@ -8,7 +8,6 @@ import {
 } from "@/lib/stage2DocumentDisplay";
 import type { Stage2Document } from "@/types/stage2Documents";
 import { formatDate } from "@/utils/format";
-import { getResolvedEoiExpiryDate } from "@/lib/stage2/eoiExpiry";
 import { Stage2RowActionsCell } from "@/components/applications/stage2/Stage2RowActionsCell";
 import {
   MotionTableRow,
@@ -38,7 +37,7 @@ export function EOIDocumentRow({
 }: EOIDocumentRowProps) {
   const motionProps = useStage2RowMotionProps(rowIndex);
   const stateLabel = document.state ? getStage2StateDisplay(document.state) : "N/A";
-  const resolvedExpiry = getResolvedEoiExpiryDate(document);
+  const interestTypeLabel = document.type === "roi" ? "ROI" : "EOI";
 
   return (
     <MotionTableRow
@@ -52,6 +51,11 @@ export function EOIDocumentRow({
         <TruncatedText className="max-w-full text-neutral-700">{document.document_name?.slice(0, 20) || document.file_name?.slice(0, 20)}</TruncatedText>
       </TableCell>
       <TableCell className="min-w-0 font-normal">
+        <Badge variant="lighter" color={document.type === "roi" ? "blue" : "green"} size="md">
+          {interestTypeLabel}
+        </Badge>
+      </TableCell>
+      <TableCell className="min-w-0 font-normal">
         <Badge variant="lighter" color="purple" size="md" className="min-w-0 max-w-full">
           <TruncatedText className="max-w-[18ch]">{stateLabel}</TruncatedText>
         </Badge>
@@ -61,16 +65,8 @@ export function EOIDocumentRow({
         <TruncatedText className="max-w-full">{getStage2SubclassDisplay(document.subclass)}</TruncatedText>
       </TableCell>
 
-      <TableCell className="whitespace-nowrap tabular-nums text-sm">
-        {document.point ?? "N/A"}
-      </TableCell>
-
       <TableCell className="whitespace-nowrap text-sm">
         {formatDate(document.date, "short")}
-      </TableCell>
-
-      <TableCell className="whitespace-nowrap text-sm tabular-nums">
-        {resolvedExpiry ? formatDate(resolvedExpiry, "short") : "—"}
       </TableCell>
 
       <Stage2RowActionsCell

--- a/src/components/applications/stage2/ViewStage2DocumentModal.tsx
+++ b/src/components/applications/stage2/ViewStage2DocumentModal.tsx
@@ -19,7 +19,8 @@ import {
 } from "@/lib/stage2DocumentDisplay";
 import { getOutcomeExpiryDisplayParts } from "@/lib/stage2/outcomeExpiry";
 import { invitationTypeLabel } from "@/lib/stage2/invitationExpiry";
-import { getResolvedEoiExpiryDate } from "@/lib/stage2/eoiExpiry";
+import { getResolvedInterestExpiryDate } from "@/lib/stage2/eoiExpiry";
+import { isInterestDocumentType } from "@/lib/stage2/interestDocument";
 import { cn } from "@/lib/utils";
 import { DocumentEmbedPreview } from "@/components/applications/document-preview/DocumentEmbedPreview";
 import { getDocumentUrl } from "@/lib/documents/getDocumentUrl";
@@ -29,6 +30,8 @@ function typeLabel(type: Stage2DocumentType) {
   switch (type) {
     case "eoi":
       return "EOI";
+    case "roi":
+      return "ROI";
     case "invitation":
       return "Invitation";
     case "outcome":
@@ -87,8 +90,10 @@ export function ViewStage2DocumentModal({
       : { type: "spring" as const, stiffness: 420, damping: 36 },
   };
 
-  const resolvedEoiExpiry =
-    document?.type === "eoi" ? getResolvedEoiExpiryDate(document) : null;
+  const resolvedInterestExpiry =
+    document && isInterestDocumentType(document.type)
+      ? getResolvedInterestExpiryDate(document)
+      : null;
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -146,7 +151,7 @@ export function ViewStage2DocumentModal({
               </div>
               <div className="min-h-0 flex-1 overflow-y-auto px-4 py-2">
                 <dl>
-                  {document.type === "eoi" && (
+                  {document.type === "eoi" || document.type === "roi" ? (
                     <>
                       <DetailRow label="State">
                         {document.state ? getStage2StateDisplay(document.state) : "N/A"}
@@ -157,8 +162,8 @@ export function ViewStage2DocumentModal({
                         {document.date ? formatDate(document.date, "short") : "N/A"}
                       </DetailRow>
                       <DetailRow label="Expiry">
-                        {resolvedEoiExpiry
-                          ? formatDate(resolvedEoiExpiry, "short")
+                        {resolvedInterestExpiry
+                          ? formatDate(resolvedInterestExpiry, "short")
                           : "—"}
                       </DetailRow>
                       <DetailRow label="Skill assessing body">
@@ -168,7 +173,7 @@ export function ViewStage2DocumentModal({
                         {getStage2AnzscoDisplay(document.language_assessing_body)}
                       </DetailRow> */}
                     </>
-                  )}
+                  ) : null}
                   {document.type === "invitation" && (
                     <>
                       <DetailRow label="Invitation type">

--- a/src/components/applications/stage2/sheets/EOISheet.tsx
+++ b/src/components/applications/stage2/sheets/EOISheet.tsx
@@ -53,11 +53,17 @@ import {
   STAGE2_STATE_NOT_APPLICABLE,
 } from "@/lib/stage2/visaSubclassState";
 import {
-  computeEoiExpiryDate,
+  computeInterestExpiryDate,
   formatEoiExpiryForApi,
   formatEoiExpiryForPatch,
-  getEoiExpiryPeriodLabel,
+  getInterestDateLabel,
+  getInterestExpiryPeriodLabel,
+  type InterestDocumentType,
 } from "@/lib/stage2/eoiExpiry";
+import {
+  getInterestUploadFields,
+  INTEREST_TYPE_OPTIONS,
+} from "@/lib/stage2/interestDocument";
 import { formatDate } from "@/utils/format";
 
 interface UploadedFile {
@@ -242,6 +248,7 @@ export function EOISheet({
   const sheetContainerRef = useRef<HTMLDivElement>(null);
 
   // Shared form fields
+  const [interestType, setInterestType] = useState<InterestDocumentType>("eoi");
   const [subclass, setSubclass] = useState("");
   const [selectedStates, setSelectedStates] = useState<string[]>([]);
   const [point, setPoint] = useState("");
@@ -296,15 +303,19 @@ export function EOISheet({
     (_, index) => (65 + index * 5).toString(),
   );
 
-  const computedExpiry = useMemo(() => computeEoiExpiryDate(date), [date]);
+  const computedExpiry = useMemo(
+    () => computeInterestExpiryDate(date, interestType),
+    [date, interestType],
+  );
 
   const expiryDisplayText = useMemo(() => {
     if (!computedExpiry) return "N/A";
-    return `${formatDate(computedExpiry, "short")} (${getEoiExpiryPeriodLabel()} from EOI date)`;
-  }, [computedExpiry]);
+    return `${formatDate(computedExpiry, "short")} (${getInterestExpiryPeriodLabel(interestType)} from ${getInterestDateLabel(interestType)})`;
+  }, [computedExpiry, interestType]);
 
   useEffect(() => {
     if (mode === "edit" && document) {
+      setInterestType(document.type === "roi" ? "roi" : "eoi");
       setSubclass(document.subclass || "");
       setSelectedStates(document.state ? [document.state] : []);
       setPoint(document.point?.toString() || "");
@@ -330,6 +341,7 @@ export function EOISheet({
       setCustomAssessingAuthority("");
       setReplacementFile(null);
     } else {
+      setInterestType("eoi");
       setSubclass("");
       setSelectedStates([]);
       setPoint("");
@@ -477,6 +489,7 @@ export function EOISheet({
               point: Number(point),
               date: formattedDate,
               skill_assessing_body: anzscoValue,
+              type: interestType,
               ...(expiryAtPatch ? { expiry_at: expiryAtPatch } : {}),
             },
           });
@@ -504,15 +517,14 @@ export function EOISheet({
 
         for (const uploadedFile of stateFiles) {
           const file = uploadedFile.file;
+          const uploadFields = getInterestUploadFields(interestType, file);
           try {
             await uploadMutation.mutateAsync({
               applicationId,
               files: [file],
               file_name: file.name,
-              document_name: file.name,
-              document_type: file.type,
+              ...uploadFields,
               uploaded_by: user?.username ?? user?.email ?? "",
-              type: "eoi",
               subclass,
               state: stateCode,
               point: Number(point),
@@ -550,6 +562,7 @@ export function EOISheet({
   };
 
   function clearFormState() {
+    setInterestType("eoi");
     setSubclass("");
     setSelectedStates([]);
     setPoint("");
@@ -598,7 +611,7 @@ export function EOISheet({
   const showProgress = mode === "create" && isUploading && totalUploads > 0;
 
   const title =
-    mode === "edit" ? "Edit EOI Document" : "Create EOI Document";
+    mode === "edit" ? "Edit EOI/ROI Document" : "Create EOI/ROI Document";
 
   return (
     <Sheet open={isOpen} onOpenChange={handleOpenChange}>
@@ -631,6 +644,33 @@ export function EOISheet({
             >
               {/* Visa Information */}
               <div className="space-y-3 px-4 py-4">
+                <div className="space-y-1.5">
+                  <Label className="text-xs font-medium text-foreground">
+                    Type *
+                  </Label>
+                  <Select
+                    value={interestType}
+                    onValueChange={(value) =>
+                      setInterestType(value as InterestDocumentType)
+                    }
+                    disabled={isUploading}
+                  >
+                    <SelectTrigger className="h-9 w-full">
+                      <SelectValue placeholder="Select type…" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectLabel>Type</SelectLabel>
+                        {INTEREST_TYPE_OPTIONS.map((opt) => (
+                          <SelectItem key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </div>
+
                 <div className="space-y-1.5">
                   <Label className="text-xs font-medium text-foreground">
                     Subclass *

--- a/src/hooks/useAvailableLayouts.ts
+++ b/src/hooks/useAvailableLayouts.ts
@@ -26,7 +26,7 @@ export function useAvailableLayouts(
     if (documentTypes.has("outcome")) {
       availableLayouts.push("outcome");
     }
-    if (documentTypes.has("eoi")) {
+    if (documentTypes.has("eoi") || documentTypes.has("roi")) {
       availableLayouts.push("eoi");
     }
     if (documentTypes.has("invitation")) {

--- a/src/lib/api/stage2Documents.ts
+++ b/src/lib/api/stage2Documents.ts
@@ -277,6 +277,13 @@ export async function updateStage2Document(
   ) {
     metadata.expiry_at = String(request.metadata.expiry_at).trim();
   }
+  if (
+    request.metadata.type !== undefined &&
+    request.metadata.type !== null &&
+    String(request.metadata.type).trim() !== ""
+  ) {
+    metadata.type = String(request.metadata.type).trim();
+  }
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",

--- a/src/lib/constants/australianData.ts
+++ b/src/lib/constants/australianData.ts
@@ -221,6 +221,11 @@ export const ANZSCO_CODES: AnzscoCode[] = [
     assessing_authority: "VETASSESS",
   },
   {
+    anzsco_code: "132511",
+    name: "Research and Development Manager",
+    assessing_authority: "VETASSESS",
+  },
+  {
     anzsco_code: "133111",
     name: "Construction Project Manager",
     assessing_authority: "VETASSESS",
@@ -510,7 +515,7 @@ export const ANZSCO_CODES: AnzscoCode[] = [
   },
   {
     anzsco_code: "212411",
-    name: "Policy Analyst",
+    name: "Copywriter",
     assessing_authority: "VETASSESS",
   },
   {
@@ -753,8 +758,23 @@ export const ANZSCO_CODES: AnzscoCode[] = [
     assessing_authority: "VETASSESS",
   },
   {
+    anzsco_code: "225112",
+    name: "Market Research Analyst",
+    assessing_authority: "VETASSESS",
+  },
+  {
     anzsco_code: "225113",
     name: "Marketing Specialist",
+    assessing_authority: "VETASSESS",
+  },
+  {
+    anzsco_code: "225211",
+    name: "ICT Account Manager",
+    assessing_authority: "ACS",
+  },
+  {
+    anzsco_code: "225499",
+    name: "Technical Sales Representative nec",
     assessing_authority: "VETASSESS",
   },
   {
@@ -891,6 +911,11 @@ export const ANZSCO_CODES: AnzscoCode[] = [
   {
     anzsco_code: "233512",
     name: "Mechanical Engineer",
+    assessing_authority: "Engineers Australia",
+  },
+  {
+    anzsco_code: "233513",
+    name: "Production or Plant Engineer",
     assessing_authority: "Engineers Australia",
   },
   {
@@ -1113,6 +1138,11 @@ export const ANZSCO_CODES: AnzscoCode[] = [
     assessing_authority: "VETASSESS",
   },
   { anzsco_code: "251111", name: "Dietitian", assessing_authority: "DAA" },
+  {
+    anzsco_code: "251112",
+    name: "Nutritionist",
+    assessing_authority: "DAA",
+  },
   {
     anzsco_code: "251211",
     name: "Medical Diagnostic Radiographer",
@@ -2292,6 +2322,11 @@ export const ANZSCO_CODES: AnzscoCode[] = [
   {
     anzsco_code: "511112",
     name: "Programme or Project Administrator",
+    assessing_authority: "VETASSESS",
+  },
+  {
+    anzsco_code: "599915",
+    name: "Technical Writer nec",
     assessing_authority: "VETASSESS",
   },
   {

--- a/src/lib/stage2/eoiExpiry.ts
+++ b/src/lib/stage2/eoiExpiry.ts
@@ -1,49 +1,76 @@
-import { addYears, format, isValid, parseISO } from "date-fns";
+import { addMonths, addYears, format, isValid, parseISO } from "date-fns";
 import type { Stage2Document } from "@/types/stage2Documents";
 
-/** SkillSelect EOI validity from the EOI date (common rule of thumb). */
 const EOI_VALIDITY_YEARS = 2;
+const ROI_VALIDITY_MONTHS = 6;
+
+export type InterestDocumentType = "eoi" | "roi";
+
+export function computeInterestExpiryDate(
+  interestDate: Date | null | undefined,
+  type: InterestDocumentType,
+): Date | null {
+  if (!interestDate || !isValid(interestDate)) return null;
+  if (type === "roi") {
+    return addMonths(interestDate, ROI_VALIDITY_MONTHS);
+  }
+  return addYears(interestDate, EOI_VALIDITY_YEARS);
+}
+
+export function getInterestExpiryPeriodLabel(type: InterestDocumentType): string {
+  if (type === "roi") return `${ROI_VALIDITY_MONTHS} months`;
+  return `${EOI_VALIDITY_YEARS} years`;
+}
+
+export function getInterestDateLabel(type: InterestDocumentType): string {
+  return type === "roi" ? "ROI date" : "EOI date";
+}
 
 export function computeEoiExpiryDate(
   eoiDate: Date | null | undefined,
 ): Date | null {
-  if (!eoiDate || !isValid(eoiDate)) return null;
-  return addYears(eoiDate, EOI_VALIDITY_YEARS);
+  return computeInterestExpiryDate(eoiDate, "eoi");
 }
 
 export function getEoiExpiryPeriodLabel(): string {
-  return `${EOI_VALIDITY_YEARS} years`;
+  return getInterestExpiryPeriodLabel("eoi");
 }
 
-/** POST multipart / FormData */
 export function formatEoiExpiryForApi(date: Date): string {
   return format(date, "yyyy-MM-dd");
 }
 
-/** JSON PATCH (ISO), aligned with invitation expiry patch */
 export function formatEoiExpiryForPatch(date: Date): string {
   const d = new Date(date);
   d.setUTCHours(0, 0, 0, 0);
   return d.toISOString();
 }
 
-/**
- * Expiry for display: prefer stored `expiry_at`; if missing, use EOI `date` + validity window
- * (same as {@link computeEoiExpiryDate}) so legacy documents without `expiry_at` still show expiry.
- */
-export function getResolvedEoiExpiryDate(
-  doc: Pick<Stage2Document, "expiry_at" | "date">,
+function resolveInterestType(
+  doc: Pick<Stage2Document, "type" | "expiry_at" | "date">,
+): InterestDocumentType {
+  return doc.type === "roi" ? "roi" : "eoi";
+}
+
+export function getResolvedInterestExpiryDate(
+  doc: Pick<Stage2Document, "type" | "expiry_at" | "date">,
 ): Date | null {
   const stored = doc.expiry_at?.trim();
   if (stored) {
     const parsed = parseISO(stored);
     if (isValid(parsed)) return parsed;
   }
-  const eoiDateStr = doc.date?.trim();
-  if (!eoiDateStr) return null;
+  const interestDateStr = doc.date?.trim();
+  if (!interestDateStr) return null;
   const base = parseISO(
-    eoiDateStr.length === 10 ? `${eoiDateStr}T12:00:00` : eoiDateStr,
+    interestDateStr.length === 10 ? `${interestDateStr}T12:00:00` : interestDateStr,
   );
   if (!isValid(base)) return null;
-  return computeEoiExpiryDate(base);
+  return computeInterestExpiryDate(base, resolveInterestType(doc));
+}
+
+export function getResolvedEoiExpiryDate(
+  doc: Pick<Stage2Document, "type" | "expiry_at" | "date">,
+): Date | null {
+  return getResolvedInterestExpiryDate(doc);
 }

--- a/src/lib/stage2/interestDocument.ts
+++ b/src/lib/stage2/interestDocument.ts
@@ -1,0 +1,23 @@
+import type { InterestDocumentType } from "@/lib/stage2/eoiExpiry";
+
+export const INTEREST_TYPE_OPTIONS = [
+  { value: "eoi", label: "Expression of Interest (EOI)" },
+  { value: "roi", label: "Register of Interest (ROI)" },
+] as const;
+
+export function getInterestUploadFields(
+  type: InterestDocumentType,
+  file: File,
+) {
+  return {
+    type,
+    document_name: file.name,
+    document_type: file.type,
+  };
+}
+
+export function isInterestDocumentType(
+  type: string | undefined | null,
+): type is InterestDocumentType {
+  return type === "eoi" || type === "roi";
+}

--- a/src/types/stage2Documents.d.ts
+++ b/src/types/stage2Documents.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Stage 2 Documents (Outcome, EOI, Invitation)
 
-export type Stage2DocumentType = "outcome" | "eoi" | "invitation";
+export type Stage2DocumentType = "outcome" | "eoi" | "roi" | "invitation";
 
 export interface Stage2Document {
   _id: string;
@@ -73,6 +73,7 @@ export interface UpdateStage2DocumentRequest {
     outcome?: string;
     skill_assessing_body?: string;
     expiry_at?: string;
+    type?: Stage2DocumentType;
   };
 }
 


### PR DESCRIPTION
- Updated components and hooks to handle both Expression of Interest (EOI) and Register of Interest (ROI) document types.
- Refactored document queries and state management to accommodate the new ROI type.
- Enhanced UI elements to reflect the dual document types, including labels and display logic.
- Introduced new utility functions for managing interest document types and their expiry calculations.
- Updated API interactions to support the new document structure, ensuring consistency across the application.